### PR TITLE
fix(lint): suppress gosec false positive and bump golangci-lint to v2.11.3

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,9 +24,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:
           repo: golangci/golangci-lint
-          tag: v2.4.0
+          tag: v2.11.3
           cache: enable
-          binaries-location: golangci-lint-2.4.0-linux-amd64
+          binaries-location: golangci-lint-2.11.3-linux-amd64
 
       - name: Run linter
         shell: /usr/bin/bash {0}

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -512,7 +512,7 @@ func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, a
 	}
 
 	// Construct the EXPLAIN query
-	explainQuery := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + query
+	explainQuery := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + query //nolint:gosec // query is validated by validateQuery above (SELECT/WITH only)
 
 	rows, err := c.db.QueryContext(ctx, explainQuery, args...)
 	if err != nil {


### PR DESCRIPTION
- Add //nolint:gosec directive on ExplainQuery SQL concatenation (query is
  pre-validated by validateQuery to allow only SELECT/WITH)
- Bump golangci-lint from v2.4.0 to v2.11.3 in CI workflow

Closes #55