### PR TITLE
fix(client): run validateQuery before c.db == nil check (#99)

### DIFF
--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -740,12 +740,12 @@ func processRows(rows *sql.Rows, maxRows int) ([][]any, error) {
 
 // ExecuteQuery executes a SELECT query and returns the results.
 func (c *PostgreSQLClientImpl) ExecuteQuery(ctx context.Context, query string, args ...any) (*QueryResult, error) {
-	if c.db == nil {
-		return nil, ErrNoDatabaseConnection
-	}
-
 	if err := validateQuery(query); err != nil {
 		return nil, err
+	}
+
+	if c.db == nil {
+		return nil, ErrNoDatabaseConnection
 	}
 
 	rows, err := c.db.QueryContext(ctx, query, args...)
@@ -776,12 +776,12 @@ func (c *PostgreSQLClientImpl) ExecuteQuery(ctx context.Context, query string, a
 
 // ExplainQuery returns the execution plan for a query.
 func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, args ...any) (*QueryResult, error) {
-	if c.db == nil {
-		return nil, ErrNoDatabaseConnection
-	}
-
 	if err := validateQuery(query); err != nil {
 		return nil, err
+	}
+
+	if c.db == nil {
+		return nil, ErrNoDatabaseConnection
 	}
 
 	// Construct the EXPLAIN query

--- a/internal/app/client_mocked_test.go
+++ b/internal/app/client_mocked_test.go
@@ -97,10 +97,9 @@ func TestPostgreSQLClient_QueryValidationLogic(t *testing.T) {
 			shouldAllow: true,
 		},
 		{
-			name:          "select lowercase",
-			query:         "select * from users",
-			shouldAllow:   false,
-			expectedError: "only SELECT and WITH queries are allowed",
+			name:        "select lowercase is allowed (validator is case-insensitive)",
+			query:       "select * from users",
+			shouldAllow: true,
 		},
 		{
 			name:          "INSERT query",
@@ -130,19 +129,18 @@ func TestPostgreSQLClient_QueryValidationLogic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test the validation logic that would happen in ExecuteQuery
-			// by calling it without a real database connection
+			// Validation must run before the connection check so that
+			// disallowed queries are rejected with a clear error even when
+			// the client is disconnected (issue #99).
 			_, err := client.ExecuteQuery(context.Background(), tt.query)
 
+			assert.Error(t, err)
 			if tt.shouldAllow {
-				// Should fail with connection error, not validation error
-				assert.Error(t, err)
+				// SELECT/WITH passes validation; fails on missing connection.
 				assert.Contains(t, err.Error(), "no database connection")
 			} else {
-				// Should fail with validation error even before checking connection
-				// But our current implementation checks connection first, so we expect connection error
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "no database connection")
+				// Validation error surfaces regardless of connection state.
+				assert.Contains(t, err.Error(), tt.expectedError)
 			}
 		})
 	}

--- a/internal/app/client_test.go
+++ b/internal/app/client_test.go
@@ -268,7 +268,7 @@ func TestPostgreSQLClient_ExecuteQueryInvalidQueries(t *testing.T) {
 			name:        "Query with mixed case",
 			query:       "select * from users",
 			expectError: true,
-			errorMsg:    "only SELECT and WITH queries are allowed",
+			errorMsg:    "no database connection",
 		},
 	}
 
@@ -277,11 +277,9 @@ func TestPostgreSQLClient_ExecuteQueryInvalidQueries(t *testing.T) {
 			result, err := client.ExecuteQuery(context.Background(), tt.query)
 			if tt.expectError {
 				assert.Error(t, err)
-				if tt.errorMsg == "only SELECT and WITH queries are allowed" {
-					assert.Contains(t, err.Error(), "no database connection")
-				} else {
-					assert.Contains(t, err.Error(), tt.errorMsg)
-				}
+				// Validation now runs before the connection check (issue #99),
+				// so the real validation error surfaces regardless of state.
+				assert.Contains(t, err.Error(), tt.errorMsg)
 				assert.Nil(t, result)
 			} else {
 				assert.NoError(t, err)
@@ -289,6 +287,40 @@ func TestPostgreSQLClient_ExecuteQueryInvalidQueries(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99 asserts
+// that disallowed queries are rejected with the real validation error even
+// when the client has no database connection. Regression for issue #99
+// (validation was previously masked by the early "no database connection"
+// check, so callers saw misleading errors and security checks did not run
+// on disconnected clients).
+func TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99(t *testing.T) {
+	client := &PostgreSQLClientImpl{} // c.db is nil
+
+	t.Run("ExecuteQuery rejects DELETE before connection check", func(t *testing.T) {
+		_, err := client.ExecuteQuery(context.Background(), "DELETE FROM users")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only SELECT and WITH queries are allowed")
+	})
+
+	t.Run("ExplainQuery rejects DROP before connection check", func(t *testing.T) {
+		_, err := client.ExplainQuery(context.Background(), "DROP TABLE users")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only SELECT and WITH queries are allowed")
+	})
+
+	t.Run("ExecuteQuery still reports missing connection for valid queries", func(t *testing.T) {
+		_, err := client.ExecuteQuery(context.Background(), "SELECT 1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no database connection")
+	})
+
+	t.Run("ExplainQuery still reports missing connection for valid queries", func(t *testing.T) {
+		_, err := client.ExplainQuery(context.Background(), "SELECT 1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no database connection")
+	})
 }
 
 func TestPostgreSQLClient_ExplainQueryWithoutConnection(t *testing.T) {


### PR DESCRIPTION
Closes #99.

\`ExecuteQuery\` and \`ExplainQuery\` checked the database handle before calling \`validateQuery\`, so an invalid query against a disconnected client returned \`ErrNoDatabaseConnection\` instead of the real validation error, and the SELECT/WITH-only security guard never ran on disconnected clients. The bug was encoded as a test invariant (\`client_test.go:280-282\` replacing \`only SELECT and WITH queries are allowed\` with \`no database connection\`).

Changes:
- Swap the order in both \`ExecuteQuery\` and \`ExplainQuery\` so \`validateQuery\` runs first.
- Update \`TestPostgreSQLClient_ExecuteQueryInvalidQueries\` and \`TestPostgreSQLClient_QueryValidationLogic\` to assert the real validation error.
- Add \`TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99\` as a focused regression covering both methods on disallowed and valid queries; verified failing on the old ordering and passing on the fix.

\`SKIP_INTEGRATION_TESTS=true go test ./...\` passes locally.