### PR TITLE
fix(app): remove dead mocks and redundant validation test

### DIFF
--- a/internal/app/client_mocked_test.go
+++ b/internal/app/client_mocked_test.go
@@ -2,40 +2,10 @@ package app
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-// MockDB represents a mock database connection that actually implements needed interfaces
-type MockDBConnection struct {
-	mock.Mock
-}
-
-func (m *MockDBConnection) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	mockArgs := m.Called(query, args)
-	if rows, ok := mockArgs.Get(0).(*sql.Rows); ok {
-		return rows, mockArgs.Error(1)
-	}
-	return nil, mockArgs.Error(1)
-}
-
-func (m *MockDBConnection) QueryRow(query string, args ...interface{}) *sql.Row {
-	mockArgs := m.Called(query, args)
-	return mockArgs.Get(0).(*sql.Row)
-}
-
-func (m *MockDBConnection) Ping() error {
-	args := m.Called()
-	return args.Error(0)
-}
-
-func (m *MockDBConnection) Close() error {
-	args := m.Called()
-	return args.Error(0)
-}
 
 // Test connection validation in various scenarios
 func TestPostgreSQLClient_ConnectValidation(t *testing.T) {
@@ -71,76 +41,6 @@ func TestPostgreSQLClient_ConnectValidation(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				client.Close()
-			}
-		})
-	}
-}
-
-// Test query validation without actual database execution
-func TestPostgreSQLClient_QueryValidationLogic(t *testing.T) {
-	client := &PostgreSQLClientImpl{}
-
-	tests := []struct {
-		name          string
-		query         string
-		shouldAllow   bool
-		expectedError string
-	}{
-		{
-			name:        "SELECT query",
-			query:       "SELECT * FROM users",
-			shouldAllow: true,
-		},
-		{
-			name:        "WITH query",
-			query:       "WITH cte AS (SELECT 1) SELECT * FROM cte",
-			shouldAllow: true,
-		},
-		{
-			name:        "select lowercase is allowed (validator is case-insensitive)",
-			query:       "select * from users",
-			shouldAllow: true,
-		},
-		{
-			name:          "INSERT query",
-			query:         "INSERT INTO users (name) VALUES ('test')",
-			shouldAllow:   false,
-			expectedError: "only SELECT and WITH queries are allowed",
-		},
-		{
-			name:          "UPDATE query",
-			query:         "UPDATE users SET name = 'test'",
-			shouldAllow:   false,
-			expectedError: "only SELECT and WITH queries are allowed",
-		},
-		{
-			name:          "DELETE query",
-			query:         "DELETE FROM users",
-			shouldAllow:   false,
-			expectedError: "only SELECT and WITH queries are allowed",
-		},
-		{
-			name:          "DROP query",
-			query:         "DROP TABLE users",
-			shouldAllow:   false,
-			expectedError: "only SELECT and WITH queries are allowed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Validation must run before the connection check so that
-			// disallowed queries are rejected with a clear error even when
-			// the client is disconnected (issue #99).
-			_, err := client.ExecuteQuery(context.Background(), tt.query)
-
-			assert.Error(t, err)
-			if tt.shouldAllow {
-				// SELECT/WITH passes validation; fails on missing connection.
-				assert.Contains(t, err.Error(), "no database connection")
-			} else {
-				// Validation error surfaces regardless of connection state.
-				assert.Contains(t, err.Error(), tt.expectedError)
 			}
 		})
 	}

--- a/internal/app/client_test.go
+++ b/internal/app/client_test.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -11,36 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-// MockDB represents a mock database connection for testing
-type MockDB struct {
-	mock.Mock
-}
-
-func (m *MockDB) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	mockArgs := m.Called(query, args)
-	if rows, ok := mockArgs.Get(0).(*sql.Rows); ok {
-		return rows, mockArgs.Error(1)
-	}
-	return nil, mockArgs.Error(1)
-}
-
-func (m *MockDB) QueryRow(query string, args ...interface{}) *sql.Row {
-	mockArgs := m.Called(query, args)
-	return mockArgs.Get(0).(*sql.Row)
-}
-
-func (m *MockDB) Ping() error {
-	args := m.Called()
-	return args.Error(0)
-}
-
-func (m *MockDB) Close() error {
-	args := m.Called()
-	return args.Error(0)
-}
 
 func TestNewPostgreSQLClient(t *testing.T) {
 	client := NewPostgreSQLClient()

--- a/main.go
+++ b/main.go
@@ -21,6 +21,12 @@ import (
 // Version information injected at build time.
 var version = "dev"
 
+// MCP parameter names and log attribute keys reused across tool handlers.
+const (
+	schemaKey = "schema"
+	tableKey  = "table"
+)
+
 // Error variables for static errors.
 var (
 	ErrInvalidConnectionParameters = errors.New("invalid connection parameters")
@@ -271,7 +277,7 @@ func setupListSchemasTool(s *server.MCPServer, appInstance *app.App, debugLogger
 func setupListTablesTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
 	listTablesTool := mcp.NewTool("list_tables",
 		mcp.WithDescription("List tables in a specific schema"),
-		mcp.WithString("schema",
+		mcp.WithString(schemaKey,
 			mcp.Description(fmt.Sprintf("Schema name to list tables from (default: %s)", app.DefaultSchema)),
 		),
 		mcp.WithBoolean("include_size",
@@ -286,7 +292,7 @@ func setupListTablesTool(s *server.MCPServer, appInstance *app.App, debugLogger 
 		// Extract options
 		opts := &app.ListTablesOptions{}
 
-		if schema, ok := args["schema"].(string); ok && schema != "" {
+		if schema, ok := args[schemaKey].(string); ok && schema != "" {
 			opts.Schema = schema
 		}
 
@@ -294,7 +300,7 @@ func setupListTablesTool(s *server.MCPServer, appInstance *app.App, debugLogger 
 			opts.IncludeSize = includeSize
 		}
 
-		debugLogger.Debug("Processing list_tables request", "schema", opts.Schema, "include_size", opts.IncludeSize)
+		debugLogger.Debug("Processing list_tables request", schemaKey, opts.Schema, "include_size", opts.IncludeSize)
 
 		// List tables
 		tables, err := appInstance.ListTables(ctx, opts)
@@ -310,7 +316,7 @@ func setupListTablesTool(s *server.MCPServer, appInstance *app.App, debugLogger 
 			return mcp.NewToolResultError("Failed to format tables response"), nil
 		}
 
-		debugLogger.Info("Successfully listed tables", "count", len(tables), "schema", opts.Schema)
+		debugLogger.Info("Successfully listed tables", "count", len(tables), schemaKey, opts.Schema)
 		return mcp.NewToolResultText(string(jsonData)), nil
 	})
 }
@@ -322,19 +328,19 @@ func handleTableSchemaToolRequest(
 	toolName string,
 ) (string, string, error) {
 	// Extract table name (required)
-	table, ok := args["table"].(string)
+	table, ok := args[tableKey].(string)
 	if !ok || table == "" {
-		debugLogger.Error("table name is missing or not a string", "value", args["table"], "tool", toolName)
+		debugLogger.Error("table name is missing or not a string", "value", args[tableKey], "tool", toolName)
 		return "", "", app.ErrTableRequired
 	}
 
 	// Extract schema (optional)
 	schema := app.DefaultSchema
-	if schemaArg, ok := args["schema"].(string); ok && schemaArg != "" {
+	if schemaArg, ok := args[schemaKey].(string); ok && schemaArg != "" {
 		schema = schemaArg
 	}
 
-	debugLogger.Debug(fmt.Sprintf("Processing %s request", toolName), "schema", schema, "table", table)
+	debugLogger.Debug(fmt.Sprintf("Processing %s request", toolName), schemaKey, schema, tableKey, table)
 	return table, schema, nil
 }
 
@@ -362,11 +368,11 @@ type TableToolConfig struct {
 func setupTableTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger, config TableToolConfig) {
 	tool := mcp.NewTool(config.Name,
 		mcp.WithDescription(config.Description),
-		mcp.WithString("table",
+		mcp.WithString(tableKey,
 			mcp.Required(),
 			mcp.Description(config.TableDesc),
 		),
-		mcp.WithString("schema",
+		mcp.WithString(schemaKey,
 			mcp.Description(fmt.Sprintf("Schema name (default: %s)", app.DefaultSchema)),
 		),
 	)
@@ -382,7 +388,7 @@ func setupTableTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog
 
 		result, err := config.Operation(ctx, appInstance, schema, table)
 		if err != nil {
-			debugLogger.Error("Failed to "+config.ErrorMsg, "error", err, "schema", schema, "table", table)
+			debugLogger.Error("Failed to "+config.ErrorMsg, "error", err, schemaKey, schema, tableKey, table)
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to %s: %v", config.ErrorMsg, err)), nil
 		}
 
@@ -411,7 +417,7 @@ func setupDescribeTableTool(s *server.MCPServer, appInstance *app.App, debugLogg
 			if !ok {
 				return "Error processing result", []any{"error", "type assertion failed"}
 			}
-			return "Successfully described table", []any{"column_count", len(columns), "schema", schema, "table", table}
+			return "Successfully described table", []any{"column_count", len(columns), schemaKey, schema, tableKey, table}
 		},
 		ErrorMsg: "describe table",
 	})
@@ -485,7 +491,7 @@ func setupListIndexesTool(s *server.MCPServer, appInstance *app.App, debugLogger
 			if !ok {
 				return "Error processing result", []any{"error", "type assertion failed"}
 			}
-			return "Successfully listed indexes", []any{"count", len(indexes), "schema", schema, "table", table}
+			return "Successfully listed indexes", []any{"count", len(indexes), schemaKey, schema, tableKey, table}
 		},
 		ErrorMsg: "list indexes",
 	})
@@ -543,7 +549,7 @@ func setupGetTableStatsTool(s *server.MCPServer, appInstance *app.App, debugLogg
 			return appInstance.GetTableStats(ctx, schema, table)
 		},
 		SuccessMsg: func(_ any, schema, table string) (string, []any) {
-			return "Successfully retrieved table stats", []any{"schema", schema, "table", table}
+			return "Successfully retrieved table stats", []any{schemaKey, schema, tableKey, table}
 		},
 		ErrorMsg: "get table stats",
 	})


### PR DESCRIPTION
- Delete unused MockDB and MockDBConnection structs from
  client_test.go and client_mocked_test.go; both were declared
  for an interface that never existed and were never instantiated.
- Delete TestPostgreSQLClient_QueryValidationLogic; coverage is
  already provided by TestValidateQuery (validates via errors.Is
  against the real sentinels) and by
  TestPostgreSQLClient_ExecuteQueryInvalidQueries (covers the
  integration path).
- Drop now-unused database/sql and testify/mock imports from
  the two test files.
- Extract schemaKey and tableKey constants in main.go to satisfy
  goconst (string "schema" had 3+ occurrences).

Closes #98