### PR TITLE
fix(app): eliminate data race on *sql.DB pointer during reconnect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mark3labs/mcp-go v0.50.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	golang.org/x/sync v0.19.0
 )
 
 require (

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -775,4 +776,58 @@ func TestIntegration_PoolConfiguration(t *testing.T) {
 
 	stats := db.Stats()
 	assert.Equal(t, 10, stats.MaxOpenConnections, "MaxOpenConns should be 10")
+}
+
+// TestIntegration_ConcurrentQueriesAndReconnect_NoRace_Issue83 verifies that
+// concurrent query goroutines do not race against a goroutine calling Connect
+// (which swaps the underlying *sql.DB pool). Run with `go test -race` to
+// detect the unsynchronized pointer access fixed in issue #83.
+func TestIntegration_ConcurrentQueriesAndReconnect_NoRace_Issue83(t *testing.T) {
+	_, connectionString, cleanup := setupTestContainer(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client := app.NewPostgreSQLClient()
+	require.NoError(t, client.Connect(ctx, connectionString))
+	defer client.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Query workers: hammer the client with read-only queries.
+	const queryWorkers = 16
+	for range queryWorkers {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					// Errors during a reconnect window ("sql: database is closed",
+					// transient connection drops) are expected and intentionally
+					// ignored — we only care that no data race is detected.
+					_, _ = client.ExecuteQuery(ctx, "SELECT 1")
+				}
+			}
+		})
+	}
+
+	// Reconnector: periodically swap in a fresh *sql.DB pool, racing the readers.
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = client.Connect(ctx, connectionString)
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	})
+
+	time.Sleep(500 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/sylvain/postgresql-mcp/internal/logger"
+	"golang.org/x/sync/singleflight"
 )
 
 // Constants for default values.
@@ -39,9 +40,14 @@ type ExecuteQueryOptions struct {
 }
 
 // App represents the main application structure.
+//
+// reconnectGroup dedupes concurrent reconnect attempts so that N handler
+// goroutines observing the same connection failure trigger only one
+// underlying Connect call (issue #83).
 type App struct {
-	client PostgreSQLClient
-	logger *slog.Logger
+	client         PostgreSQLClient
+	logger         *slog.Logger
+	reconnectGroup singleflight.Group
 }
 
 // New creates a new App instance with the provided PostgreSQLClient.
@@ -383,14 +389,16 @@ func (a *App) tryConnect(ctx context.Context) error {
 //
 // This method is called before every database operation to provide transparent
 // connection recovery. If the connection ping fails, it attempts to reconnect
-// once using the original connection parameters from POSTGRES_URL or DATABASE_URL
+// using the original connection parameters from POSTGRES_URL or DATABASE_URL
 // environment variables.
 //
 // Reconnection behavior:
-//   - Single reconnection attempt per operation (no retries or backoff)
-//   - Uses a background context so reconnection is not cancelled by request timeout
-//   - Logs reconnection attempts at Debug level and results at Info/Error level
-//   - Returns ErrConnectionRequired if the client is nil or reconnection fails
+//   - Concurrent reconnect attempts are deduped via singleflight, so N handlers
+//     observing the same failure trigger only one underlying Connect (issue #83).
+//   - Uses a background context so reconnection is not cancelled by request timeout.
+//   - Followers honor their own request ctx and may abort while the leader runs.
+//   - Logs reconnection attempts at Debug level and results at Info/Error level.
+//   - Returns ErrConnectionRequired if the client is nil or reconnection fails.
 //
 // Operations may experience a slight delay during reconnection. For environments
 // where connection stability is critical, configure shorter pool lifetimes via
@@ -400,22 +408,51 @@ func (a *App) ensureConnection(ctx context.Context) error {
 		return ErrConnectionRequired
 	}
 
-	// Test current connection with request context
-	if err := a.client.Ping(ctx); err != nil {
-		a.logger.Debug("Database connection lost, attempting to reconnect", "error", err)
-
-		// Attempt to reconnect using background context
-		// Reconnection is infrastructure work and shouldn't be cancelled by request timeout
-		reconnectCtx := context.Background()
-		if reconnectErr := a.tryConnect(reconnectCtx); reconnectErr != nil { //nolint:contextcheck // Intentional: reconnection must not be cancelled by request context
-			a.logger.Error("Failed to reconnect to database", "ping_error", err, "reconnect_error", reconnectErr)
-			return ErrConnectionRequired
-		}
-
-		a.logger.Info("Successfully reconnected to database")
+	// Fast path: current connection is healthy.
+	if err := a.client.Ping(ctx); err == nil {
+		return nil
 	}
 
-	return nil
+	// Slow path: dedupe concurrent reconnect attempts.
+	ch := a.reconnectGroup.DoChan("reconnect", a.doReconnect)
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return ErrConnectionRequired
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for reconnect: %w", ctx.Err())
+	}
+}
+
+// reconnectResult is the singleflight payload for doReconnect. It carries no
+// data; only the error is meaningful. A typed value is returned (rather than
+// nil) so the singleflight callback satisfies linters that forbid (nil, nil).
+type reconnectResult struct{}
+
+// doReconnect is the singleflight leader callback for ensureConnection.
+// Only one goroutine runs this at a time per key; concurrent callers share
+// its result.
+func (a *App) doReconnect() (any, error) {
+	// Reconnection is infrastructure work and must not be cancelled by any
+	// individual request context.
+	reconnectCtx := context.Background()
+
+	// Re-check inside the leader: another reconnect (e.g. manual
+	// connect_database) may have already succeeded between our outer Ping
+	// failure and acquiring leadership.
+	if err := a.client.Ping(reconnectCtx); err == nil {
+		return reconnectResult{}, nil
+	}
+
+	a.logger.Debug("Database connection lost, attempting to reconnect")
+	if err := a.tryConnect(reconnectCtx); err != nil {
+		a.logger.Error("Failed to reconnect to database", "error", err)
+		return reconnectResult{}, err
+	}
+	a.logger.Info("Successfully reconnected to database")
+	return reconnectResult{}, nil
 }
 
 // logSecurityEvent logs a security-relevant event (e.g., rejected query)

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/lib/pq"
@@ -82,8 +83,12 @@ func injectReadOnlyOption(connStr string) string {
 }
 
 // PostgreSQLClientImpl implements the PostgreSQLClient interface.
+//
+// db is held as atomic.Pointer so that concurrent handler goroutines can
+// load the current *sql.DB without locking, while Connect can atomically
+// swap in a freshly opened pool during reconnection (issue #83).
 type PostgreSQLClientImpl struct {
-	db               *sql.DB
+	db               atomic.Pointer[sql.DB]
 	connectionString string
 }
 
@@ -145,17 +150,23 @@ func (c *PostgreSQLClientImpl) Connect(ctx context.Context, connectionString str
 		return fmt.Errorf("failed to ping database: %w", err)
 	}
 
-	c.db = db
+	// Atomic swap; close any previous pool that handler goroutines may still
+	// hold a reference to. sql.DB.Close waits for in-flight queries on that
+	// handle to drain, so concurrent readers degrade gracefully.
+	if old := c.db.Swap(db); old != nil {
+		_ = old.Close()
+	}
 	c.connectionString = connectionString
 	return nil
 }
 
 // Close closes the database connection.
 func (c *PostgreSQLClientImpl) Close() error {
-	if c.db == nil {
+	db := c.db.Swap(nil)
+	if db == nil {
 		return nil
 	}
-	if err := c.db.Close(); err != nil {
+	if err := db.Close(); err != nil {
 		return fmt.Errorf("failed to close database: %w", err)
 	}
 	return nil
@@ -163,10 +174,11 @@ func (c *PostgreSQLClientImpl) Close() error {
 
 // Ping checks if the database connection is alive.
 func (c *PostgreSQLClientImpl) Ping(ctx context.Context) error {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return ErrNoDatabaseConnection
 	}
-	if err := c.db.PingContext(ctx); err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	return nil
@@ -174,12 +186,13 @@ func (c *PostgreSQLClientImpl) Ping(ctx context.Context) error {
 
 // GetDB returns the underlying sql.DB connection.
 func (c *PostgreSQLClientImpl) GetDB() *sql.DB {
-	return c.db
+	return c.db.Load()
 }
 
 // ListDatabases returns a list of all databases on the server.
 func (c *PostgreSQLClientImpl) ListDatabases(ctx context.Context) ([]*DatabaseInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -189,7 +202,7 @@ func (c *PostgreSQLClientImpl) ListDatabases(ctx context.Context) ([]*DatabaseIn
 		WHERE datistemplate = false
 		ORDER BY datname`
 
-	rows, err := c.db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list databases: %w", err)
 	}
@@ -197,11 +210,11 @@ func (c *PostgreSQLClientImpl) ListDatabases(ctx context.Context) ([]*DatabaseIn
 
 	var databases []*DatabaseInfo
 	for rows.Next() {
-		var db DatabaseInfo
-		if err := rows.Scan(&db.Name, &db.Owner, &db.Encoding); err != nil {
+		var info DatabaseInfo
+		if err := rows.Scan(&info.Name, &info.Owner, &info.Encoding); err != nil {
 			return nil, fmt.Errorf("failed to scan database row: %w", err)
 		}
-		databases = append(databases, &db)
+		databases = append(databases, &info)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -212,12 +225,13 @@ func (c *PostgreSQLClientImpl) ListDatabases(ctx context.Context) ([]*DatabaseIn
 
 // GetCurrentDatabase returns the name of the current database.
 func (c *PostgreSQLClientImpl) GetCurrentDatabase(ctx context.Context) (string, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return "", ErrNoDatabaseConnection
 	}
 
 	var dbName string
-	err := c.db.QueryRowContext(ctx, "SELECT current_database()").Scan(&dbName)
+	err := db.QueryRowContext(ctx, "SELECT current_database()").Scan(&dbName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get current database: %w", err)
 	}
@@ -227,7 +241,8 @@ func (c *PostgreSQLClientImpl) GetCurrentDatabase(ctx context.Context) (string, 
 
 // ListSchemas returns a list of schemas in the current database.
 func (c *PostgreSQLClientImpl) ListSchemas(ctx context.Context) ([]*SchemaInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -237,7 +252,7 @@ func (c *PostgreSQLClientImpl) ListSchemas(ctx context.Context) ([]*SchemaInfo, 
 		WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
 		ORDER BY schema_name`
 
-	rows, err := c.db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list schemas: %w", err)
 	}
@@ -260,7 +275,8 @@ func (c *PostgreSQLClientImpl) ListSchemas(ctx context.Context) ([]*SchemaInfo, 
 
 // ListTables returns a list of tables in the specified schema.
 func (c *PostgreSQLClientImpl) ListTables(ctx context.Context, schema string) ([]*TableInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -286,7 +302,7 @@ func (c *PostgreSQLClientImpl) ListTables(ctx context.Context, schema string) ([
 		WHERE schemaname = $1
 		ORDER BY tablename`
 
-	rows, err := c.db.QueryContext(ctx, query, schema)
+	rows, err := db.QueryContext(ctx, query, schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tables: %w", err)
 	}
@@ -311,7 +327,8 @@ func (c *PostgreSQLClientImpl) ListTables(ctx context.Context, schema string) ([
 // This eliminates the N+1 query pattern by joining table metadata with pg_stat_user_tables.
 // For tables where statistics show 0 rows, it falls back to COUNT(*) to get actual row counts.
 func (c *PostgreSQLClientImpl) ListTablesWithStats(ctx context.Context, schema string) ([]*TableInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -351,7 +368,7 @@ func (c *PostgreSQLClientImpl) ListTablesWithStats(ctx context.Context, schema s
 			ON t.schemaname = s.schemaname AND t.tablename = s.relname
 		ORDER BY t.tablename`
 
-	rows, err := c.db.QueryContext(ctx, query, schema)
+	rows, err := db.QueryContext(ctx, query, schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list tables with stats: %w", err)
 	}
@@ -380,7 +397,7 @@ func (c *PostgreSQLClientImpl) ListTablesWithStats(ctx context.Context, schema s
 				pq.QuoteIdentifier(table.Schema),
 				pq.QuoteIdentifier(table.Name))
 			var actualCount int64
-			if err := c.db.QueryRowContext(ctx, countQuery).Scan(&actualCount); err != nil {
+			if err := db.QueryRowContext(ctx, countQuery).Scan(&actualCount); err != nil {
 				// Log warning but don't fail the entire operation
 				continue
 			}
@@ -393,7 +410,8 @@ func (c *PostgreSQLClientImpl) ListTablesWithStats(ctx context.Context, schema s
 
 // DescribeTable returns detailed column information for a table.
 func (c *PostgreSQLClientImpl) DescribeTable(ctx context.Context, schema, table string) ([]*ColumnInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -411,7 +429,7 @@ func (c *PostgreSQLClientImpl) DescribeTable(ctx context.Context, schema, table 
 		WHERE table_schema = $1 AND table_name = $2
 		ORDER BY ordinal_position`
 
-	rows, err := c.db.QueryContext(ctx, query, schema, table)
+	rows, err := db.QueryContext(ctx, query, schema, table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe table: %w", err)
 	}
@@ -440,7 +458,8 @@ func (c *PostgreSQLClientImpl) DescribeTable(ctx context.Context, schema, table 
 
 // GetTableStats returns statistics for a specific table.
 func (c *PostgreSQLClientImpl) GetTableStats(ctx context.Context, schema, table string) (*TableInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -461,7 +480,7 @@ func (c *PostgreSQLClientImpl) GetTableStats(ctx context.Context, schema, table 
 		WHERE schemaname = $1 AND relname = $2`
 
 	var rowCount sql.NullInt64
-	err := c.db.QueryRowContext(ctx, countQuery, schema, table).Scan(&rowCount)
+	err := db.QueryRowContext(ctx, countQuery, schema, table).Scan(&rowCount)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("failed to get table stats: %w", err)
 	}
@@ -475,7 +494,7 @@ func (c *PostgreSQLClientImpl) GetTableStats(ctx context.Context, schema, table 
 			pq.QuoteIdentifier(schema),
 			pq.QuoteIdentifier(table))
 		var actualCount int64
-		err := c.db.QueryRowContext(ctx, actualCountQuery).Scan(&actualCount)
+		err := db.QueryRowContext(ctx, actualCountQuery).Scan(&actualCount)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get actual row count: %w", err)
 		}
@@ -489,7 +508,8 @@ func (c *PostgreSQLClientImpl) GetTableStats(ctx context.Context, schema, table 
 
 // ListIndexes returns a list of indexes for the specified table.
 func (c *PostgreSQLClientImpl) ListIndexes(ctx context.Context, schema, table string) ([]*IndexInfo, error) {
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
@@ -515,7 +535,7 @@ func (c *PostgreSQLClientImpl) ListIndexes(ctx context.Context, schema, table st
 		GROUP BY i.relname, t.relname, ix.indisunique, ix.indisprimary, am.amname
 		ORDER BY i.relname`
 
-	rows, err := c.db.QueryContext(ctx, query, schema, table)
+	rows, err := db.QueryContext(ctx, query, schema, table)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list indexes: %w", err)
 	}
@@ -744,11 +764,12 @@ func (c *PostgreSQLClientImpl) ExecuteQuery(ctx context.Context, query string, a
 		return nil, err
 	}
 
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
-	rows, err := c.db.QueryContext(ctx, query, args...)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -780,14 +801,15 @@ func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, a
 		return nil, err
 	}
 
-	if c.db == nil {
+	db := c.db.Load()
+	if db == nil {
 		return nil, ErrNoDatabaseConnection
 	}
 
 	// Construct the EXPLAIN query
 	explainQuery := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + query //nolint:gosec // query is validated by validateQuery above (SELECT/WITH only)
 
-	rows, err := c.db.QueryContext(ctx, explainQuery, args...)
+	rows, err := db.QueryContext(ctx, explainQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute explain query: %w", err)
 	}

--- a/internal/app/concurrent_test.go
+++ b/internal/app/concurrent_test.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestApp_EnsureConnection_DedupesConcurrentReconnects_Issue83 verifies that
+// when N handler goroutines observe a connection failure simultaneously, only
+// one underlying Connect call is issued. Without the singleflight gate, N
+// concurrent reconnects could each open a fresh *sql.DB pool and the close-
+// then-reopen dance would create a thundering herd on the database.
+func TestApp_EnsureConnection_DedupesConcurrentReconnects_Issue83(t *testing.T) {
+	mockClient := &MockPostgreSQLClient{}
+	app := New(mockClient)
+	app.SetLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Ping always reports the connection as lost.
+	mockClient.On("Ping", mock.Anything).Return(errors.New("connection lost"))
+
+	// Connect "succeeds" after a delay long enough for every follower
+	// goroutine to enqueue behind the singleflight leader.
+	mockClient.On("Connect", mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) { time.Sleep(50 * time.Millisecond) }).
+		Return(nil)
+
+	// tryConnect needs a connection string from the environment.
+	t.Setenv("POSTGRES_URL", "postgres://test:test@localhost:5432/test")
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = app.ensureConnection(context.Background())
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	connectCalls := 0
+	for _, call := range mockClient.Calls {
+		if call.Method == "Connect" {
+			connectCalls++
+		}
+	}
+	assert.Equal(t, 1, connectCalls,
+		"singleflight must dedupe concurrent reconnect attempts (issue #83); got %d Connect calls", connectCalls)
+}
+
+// TestApp_EnsureConnection_FollowerHonorsCtxCancel verifies that a goroutine
+// waiting behind the singleflight leader returns when its own request context
+// is cancelled, rather than blocking until the leader finishes.
+func TestApp_EnsureConnection_FollowerHonorsCtxCancel(t *testing.T) {
+	mockClient := &MockPostgreSQLClient{}
+	app := New(mockClient)
+	app.SetLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	mockClient.On("Ping", mock.Anything).Return(errors.New("connection lost"))
+	// Leader's Connect blocks long enough that the follower's ctx times out first.
+	mockClient.On("Connect", mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) { time.Sleep(500 * time.Millisecond) }).
+		Return(nil)
+	t.Setenv("POSTGRES_URL", "postgres://test:test@localhost:5432/test")
+
+	leaderStarted := make(chan struct{})
+	go func() {
+		close(leaderStarted)
+		_ = app.ensureConnection(context.Background())
+	}()
+	<-leaderStarted
+	// Give the leader a moment to enter its Connect call.
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := app.ensureConnection(ctx)
+	elapsed := time.Since(start)
+
+	assert.Error(t, err, "follower should observe its own ctx cancellation")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"follower should return shortly after ctx expires, not wait for the leader's full Connect")
+}


### PR DESCRIPTION
- Change PostgreSQLClientImpl.db to atomic.Pointer[sql.DB] so concurrent
  handler goroutines load the current pool lock-free, while Connect can
  swap in a freshly opened pool without racing. Close() uses Swap(nil),
  and the old pool is closed after the swap (sql.DB.Close drains
  in-flight queries on that handle).
- Wrap App.ensureConnection's reconnect path with singleflight.Group so
  N handlers observing the same Ping failure trigger only one underlying
  Connect. Use DoChan + select{} so followers honor their own request
  ctx instead of blocking until the leader completes.
- Add two unit tests (concurrent_test.go): dedup verification under 20
  concurrent ensureConnection callers, and follower-honors-ctx-cancel.
- Add TestIntegration_ConcurrentQueriesAndReconnect_NoRace_Issue83
  exercising the real race scenario (16 query workers + reconnector on
  a testcontainers Postgres); passes under \`go test -race\`.
- Promote golang.org/x/sync to a direct dependency in go.mod.

Closes #83