### PR TITLE
fix(app): make reconnect sticky to the explicit connect_database session

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 
 	"github.com/sylvain/postgresql-mcp/internal/logger"
 	"golang.org/x/sync/singleflight"
@@ -44,10 +45,18 @@ type ExecuteQueryOptions struct {
 // reconnectGroup dedupes concurrent reconnect attempts so that N handler
 // goroutines observing the same connection failure trigger only one
 // underlying Connect call (issue #83).
+//
+// connStr holds the connection string from the most recent successful
+// Connect call. ensureConnection uses it for reconnects so that an
+// explicit connect_database session is not silently overridden by
+// POSTGRES_URL / DATABASE_URL on the next ping failure (issue #87).
 type App struct {
 	client         PostgreSQLClient
 	logger         *slog.Logger
 	reconnectGroup singleflight.Group
+
+	connStrMu sync.RWMutex
+	connStr   string
 }
 
 // New creates a new App instance with the provided PostgreSQLClient.
@@ -104,6 +113,12 @@ func (a *App) Connect(ctx context.Context, connectionString string) error {
 		a.logger.Error("Failed to connect to database", "error", err)
 		return fmt.Errorf("failed to connect: %w", err)
 	}
+
+	// Remember the string that established this session so that automatic
+	// reconnects target the same database (issue #87).
+	a.connStrMu.Lock()
+	a.connStr = connectionString
+	a.connStrMu.Unlock()
 
 	a.logger.Info("Successfully connected to PostgreSQL database")
 	return nil
@@ -368,19 +383,33 @@ func (a *App) ValidateConnection(ctx context.Context) error {
 	return a.ensureConnection(ctx)
 }
 
-// tryConnect attempts to connect using environment variables as a fallback mechanism.
-// Returns ErrNoConnectionString if no environment variables are set.
+// tryConnect picks the connection string for an (initial or recovery) Connect.
+//
+// Sticky-session: if a prior Connect succeeded, reuse the same connection
+// string so that auto-reconnect targets the same database the caller
+// explicitly chose via connect_database (issue #87). POSTGRES_URL /
+// DATABASE_URL are consulted only when no prior session exists, i.e. for
+// initial bootstrap.
+//
+// Returns ErrNoConnectionString if there is no stored string and no env var
+// fallback.
 func (a *App) tryConnect(ctx context.Context) error {
-	// Try environment variables as fallback
+	a.connStrMu.RLock()
+	stored := a.connStr
+	a.connStrMu.RUnlock()
+
+	if stored != "" {
+		return a.Connect(ctx, stored)
+	}
+
+	// Initial bootstrap only: env-var fallback.
 	connectionString := os.Getenv("POSTGRES_URL")
 	if connectionString == "" {
 		connectionString = os.Getenv("DATABASE_URL")
 	}
-
 	if connectionString == "" {
 		return ErrNoConnectionString
 	}
-
 	return a.Connect(ctx, connectionString)
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockPostgreSQLClient is a mock implementation of PostgreSQLClient for testing
@@ -679,4 +680,83 @@ func TestTruncateQuery(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestApp_ReconnectUsesStickyConnectionString_Issue87 verifies that after an
+// explicit Connect (e.g. via the connect_database tool), an auto-reconnect
+// triggered by a ping failure re-uses the originally-supplied connection
+// string instead of silently falling back to POSTGRES_URL / DATABASE_URL.
+// Without this fix, a network blip could switch the session to a different
+// database (issue #87).
+func TestApp_ReconnectUsesStickyConnectionString_Issue87(t *testing.T) {
+	const explicitConn = "postgres://userA:pw@host-a:5432/dbA"
+	const envFallback = "postgres://userB:pw@host-b:5432/dbB"
+
+	mockClient := &MockPostgreSQLClient{}
+	app := New(mockClient)
+
+	// Initial explicit Connect: App.Connect first calls Ping (to decide
+	// whether to Close an existing pool); we return an error so Close is
+	// skipped. Then it calls Connect with our explicit string.
+	mockClient.On("Ping", mock.Anything).Return(errors.New("no connection")).Once()
+	mockClient.On("Connect", mock.Anything, explicitConn).Return(nil)
+
+	require.NoError(t, app.Connect(context.Background(), explicitConn))
+
+	// Set an env var pointing at a DIFFERENT database — the dangerous
+	// scenario from the issue. The fix must not let this override the
+	// caller's explicit choice.
+	t.Setenv("POSTGRES_URL", envFallback)
+
+	// Sever the connection: every subsequent Ping fails.
+	mockClient.On("Ping", mock.Anything).Return(errors.New("connection lost"))
+
+	require.NoError(t, app.ensureConnection(context.Background()))
+
+	// Every Connect call must have targeted the explicit string. If the bug
+	// were present, a reconnect with `envFallback` would be issued and the
+	// mock — which has no expectation for that argument — would surface it
+	// as an unexpected Call entry.
+	var connectArgs []string
+	for _, call := range mockClient.Calls {
+		if call.Method == "Connect" {
+			connectArgs = append(connectArgs, call.Arguments[1].(string))
+		}
+	}
+	require.Len(t, connectArgs, 2, "expected initial Connect + one reconnect")
+	for _, arg := range connectArgs {
+		assert.Equal(t, explicitConn, arg,
+			"reconnect must reuse the explicit connection string, not env fallback (issue #87)")
+	}
+}
+
+// TestApp_ReconnectFallsBackToEnvOnInitialBootstrap verifies that the env-var
+// fallback still applies when no prior Connect has been made — i.e. for the
+// very first connection of a fresh process where the user has set POSTGRES_URL
+// instead of calling connect_database. This is the legitimate complement to
+// the sticky-session behavior.
+func TestApp_ReconnectFallsBackToEnvOnInitialBootstrap(t *testing.T) {
+	const envConn = "postgres://user:pw@host:5432/db"
+
+	mockClient := &MockPostgreSQLClient{}
+	app := New(mockClient)
+
+	t.Setenv("POSTGRES_URL", envConn)
+
+	// No prior Connect → connStr is empty → tryConnect must fall back to env.
+	// App.Connect's internal Ping (existing-conn check) returns err → skip Close.
+	mockClient.On("Ping", mock.Anything).Return(errors.New("no connection"))
+	mockClient.On("Connect", mock.Anything, envConn).Return(nil)
+
+	require.NoError(t, app.ensureConnection(context.Background()))
+
+	var connectArgs []string
+	for _, call := range mockClient.Calls {
+		if call.Method == "Connect" {
+			connectArgs = append(connectArgs, call.Arguments[1].(string))
+		}
+	}
+	require.Len(t, connectArgs, 1)
+	assert.Equal(t, envConn, connectArgs[0],
+		"initial bootstrap (no prior session) must still honor POSTGRES_URL")
 }


### PR DESCRIPTION
- Store the connection string from the most recent successful App.Connect
  in a mutex-guarded field on App.
- Change tryConnect to prefer the stored string over POSTGRES_URL /
  DATABASE_URL. Env vars are now only used for initial bootstrap when no
  prior Connect has been made, so a ping-failure-then-reconnect cycle no
  longer silently switches the session to whatever database the env var
  points at.
- Add TestApp_ReconnectUsesStickyConnectionString_Issue87: connects to A,
  sets POSTGRES_URL=B, triggers reconnect, and asserts every Connect call
  targets A. The mock has no expectation for Connect(B), so the test
  fails loudly if the bug reappears.
- Add TestApp_ReconnectFallsBackToEnvOnInitialBootstrap to lock in that
  env-var bootstrap still works for first-time connections.

Closes #87