### PR TITLE
fix(client): inject read-only mode for unquoted options= DSNs

### DIFF
--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -63,23 +63,34 @@ func injectReadOnlyOption(connStr string) string {
 		return u.String()
 	}
 
-	// Keyword-value style connection string
-	if strings.Contains(connStr, "options=") {
-		// Append to existing options value
-		// Handle both options='...' and options=...
-		optionsPrefix := "options='"
-		if idx := strings.Index(connStr, optionsPrefix); idx != -1 {
-			// Find closing quote
-			afterPrefix := idx + len(optionsPrefix)
-			closeIdx := strings.Index(connStr[afterPrefix:], "'")
-			if closeIdx != -1 {
-				insertPos := afterPrefix + closeIdx
-				return connStr[:insertPos] + " " + readOnlyOption + connStr[insertPos:]
-			}
-		}
-		return connStr
+	// Keyword-value style connection string.
+	optionsIdx := strings.Index(connStr, "options=")
+	if optionsIdx == -1 {
+		return connStr + " options='" + readOnlyOption + "'"
 	}
-	return connStr + " options='" + readOnlyOption + "'"
+	valStart := optionsIdx + len("options=")
+
+	// Quoted form: inject the new option before the closing quote.
+	if valStart < len(connStr) && connStr[valStart] == '\'' {
+		closeRel := strings.Index(connStr[valStart+1:], "'")
+		if closeRel == -1 {
+			// Malformed (unterminated quote): leave alone rather than corrupt the DSN.
+			return connStr
+		}
+		closeIdx := valStart + 1 + closeRel
+		return connStr[:closeIdx] + " " + readOnlyOption + connStr[closeIdx:]
+	}
+
+	// Unquoted form (issue #84): value runs to next whitespace or EOS.
+	// Rewrite as the quoted form so a multi-token options payload stays a
+	// single value; previously this branch silently returned the DSN
+	// unchanged, skipping the read-only enforcement.
+	valEnd := len(connStr)
+	if rel := strings.IndexAny(connStr[valStart:], " \t\n"); rel != -1 {
+		valEnd = valStart + rel
+	}
+	existing := connStr[valStart:valEnd]
+	return connStr[:optionsIdx] + "options='" + existing + " " + readOnlyOption + "'" + connStr[valEnd:]
 }
 
 // PostgreSQLClientImpl implements the PostgreSQLClient interface.

--- a/internal/app/client_test.go
+++ b/internal/app/client_test.go
@@ -655,6 +655,23 @@ func TestInjectReadOnlyOption(t *testing.T) {
 			input:    "host=localhost options='-c search_path=public'",
 			contains: "default_transaction_read_only",
 		},
+		{
+			// Regression for issue #84: previously fell through to the bare
+			// "return connStr" path and silently skipped the read-only guard.
+			name:     "keyword-value with unquoted options (issue #84)",
+			input:    "host=localhost options=-csome_option=on",
+			contains: "default_transaction_read_only=on",
+		},
+		{
+			name:     "unquoted options at start, other keyword after",
+			input:    "options=-csome_option=on host=localhost",
+			contains: "default_transaction_read_only=on",
+		},
+		{
+			name:     "unquoted options at end of DSN",
+			input:    "host=localhost dbname=mydb options=-cfoo=bar",
+			contains: "default_transaction_read_only=on",
+		},
 	}
 
 	for _, tt := range tests {
@@ -667,6 +684,32 @@ func TestInjectReadOnlyOption(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInjectReadOnlyOption_UnquotedOptions_ProducesValidQuotedForm asserts
+// that the unquoted-options DSN is rewritten into the quoted form, with the
+// pre-existing payload preserved alongside the injected read-only option,
+// and that no value-keyword from the remainder of the DSN was clobbered.
+// This is the structural complement to the contains-only assertion in the
+// table above and captures the regression at issue #84 in detail.
+func TestInjectReadOnlyOption_UnquotedOptions_ProducesValidQuotedForm(t *testing.T) {
+	in := "host=localhost options=-csome_option=on dbname=mydb"
+	out := injectReadOnlyOption(in)
+
+	assert.Contains(t, out, "options='-csome_option=on -c default_transaction_read_only=on'",
+		"unquoted options must be merged into a single quoted value with read-only appended")
+	assert.Contains(t, out, "host=localhost", "leading keyword must be preserved")
+	assert.Contains(t, out, "dbname=mydb", "trailing keyword must be preserved")
+}
+
+// TestInjectReadOnlyOption_UnterminatedQuotedOptions_LeftAlone covers the
+// malformed-DSN edge case: a quoted options= value with no closing quote is
+// returned unchanged rather than corrupted (the DSN was already invalid;
+// don't make it worse).
+func TestInjectReadOnlyOption_UnterminatedQuotedOptions_LeftAlone(t *testing.T) {
+	in := "host=localhost options='-c foo=bar"
+	out := injectReadOnlyOption(in)
+	assert.Equal(t, in, out)
 }
 
 func TestEnvIntOrDefault(t *testing.T) {


### PR DESCRIPTION
The keyword/value branch of injectReadOnlyOption only handled the
single-quoted form (options='...'). For DSNs like
  host=localhost options=-csome_option=on
the function detected the options= substring but failed to find the
opening quote and fell through to \`return connStr\` unchanged. Result:
default_transaction_read_only=on was silently NOT injected, and the
connection opened without the read-only enforcement that the security
model relies on as defense-in-depth against DML/DDL.

- Rewrite the keyword/value branch to detect quoted vs unquoted forms
  explicitly. Quoted: inject before the closing quote (unchanged
  behavior). Unquoted: scan to the next whitespace/EOS and rewrite as
  the quoted form, preserving the existing payload alongside the new
  -c default_transaction_read_only=on.
- Malformed DSNs (unterminated single quote) are returned unchanged
  rather than corrupted further.
- Add regression cases to TestInjectReadOnlyOption covering unquoted
  options at start/middle/end of the DSN, plus two focused tests:
  TestInjectReadOnlyOption_UnquotedOptions_ProducesValidQuotedForm
  asserts the structural rewrite, and
  TestInjectReadOnlyOption_UnterminatedQuotedOptions_LeftAlone covers
  the malformed-DSN edge case.

Closes #84