### PR TITLE
fix(main): validate sslmode and URL-encode credentials in buildConnectionString

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -33,7 +36,20 @@ var (
 	ErrHostRequired                = errors.New("host is required")
 	ErrUserRequired                = errors.New("user is required")
 	ErrDatabaseRequired            = errors.New("database is required")
+	ErrInvalidSSLMode              = errors.New("invalid sslmode")
 )
+
+// validSSLModes is the libpq-recognised allowlist for the sslmode parameter.
+// Any other value would either silently downgrade TLS or, when crafted as
+// e.g. "prefer&extra=value", inject unintended URL parameters (issue #86).
+var validSSLModes = map[string]struct{}{
+	"disable":     {},
+	"allow":       {},
+	"prefer":      {},
+	"require":     {},
+	"verify-ca":   {},
+	"verify-full": {},
+}
 
 // ConnectionParams represents individual database connection parameters.
 type ConnectionParams struct {
@@ -45,8 +61,14 @@ type ConnectionParams struct {
 	SSLMode  string
 }
 
-// buildConnectionString builds a PostgreSQL connection URL from individual parameters.
-// Returns the connection string or an error if required parameters are missing.
+// buildConnectionString builds a PostgreSQL connection URL from individual
+// parameters. Credentials are percent-encoded via net/url so passwords
+// containing @, /, ?, or # round-trip correctly; sslmode is validated
+// against the libpq allowlist so a crafted value cannot inject extra URL
+// parameters or silently downgrade TLS (issue #86).
+//
+// Returns an error if a required parameter is missing or if sslmode is not
+// one of: disable, allow, prefer, require, verify-ca, verify-full.
 func buildConnectionString(params ConnectionParams) (string, error) {
 	// Validate required parameters
 	if params.Host == "" {
@@ -69,19 +91,24 @@ func buildConnectionString(params ConnectionParams) (string, error) {
 	if sslMode == "" {
 		sslMode = "prefer" // PostgreSQL default SSL mode
 	}
+	if _, ok := validSSLModes[sslMode]; !ok {
+		return "", fmt.Errorf("%w: %q (allowed: disable, allow, prefer, require, verify-ca, verify-full)",
+			ErrInvalidSSLMode, sslMode)
+	}
 
-	// Build connection string using net.JoinHostPort pattern
-	hostPort := fmt.Sprintf("%s:%d", params.Host, port)
-	connStr := fmt.Sprintf(
-		"postgres://%s:%s@%s/%s?sslmode=%s",
-		params.User,
-		params.Password,
-		hostPort,
-		params.Database,
-		sslMode,
-	)
-
-	return connStr, nil
+	// Build via net/url so credentials and host are encoded correctly. Use
+	// UserPassword unconditionally (even with empty password) so the URL
+	// keeps the "user:@host" shape callers expect.
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(params.User, params.Password),
+		Host:   net.JoinHostPort(params.Host, strconv.Itoa(port)),
+		Path:   "/" + params.Database,
+	}
+	q := u.Query()
+	q.Set("sslmode", sslMode)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // extractConnectionParams extracts connection parameters from args.

--- a/main_additional_test.go
+++ b/main_additional_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"flag"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test the command line flag handling functions directly
@@ -363,4 +365,92 @@ func TestBuildConnectionString_CustomPort(t *testing.T) {
 	connStr, err := buildConnectionString(params)
 	assert.NoError(t, err)
 	assert.Equal(t, "postgres://admin:secret@dbserver:5433/mydb?sslmode=require", connStr)
+}
+
+// TestBuildConnectionString_AcceptsAllValidSSLModes locks in the libpq
+// allowlist that buildConnectionString recognises (issue #86).
+func TestBuildConnectionString_AcceptsAllValidSSLModes(t *testing.T) {
+	for _, sm := range []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"} {
+		t.Run(sm, func(t *testing.T) {
+			params := ConnectionParams{
+				Host:     "h",
+				User:     "u",
+				Password: "p",
+				Database: "d",
+				SSLMode:  sm,
+			}
+			connStr, err := buildConnectionString(params)
+			require.NoError(t, err)
+			assert.Contains(t, connStr, "sslmode="+sm)
+		})
+	}
+}
+
+// TestBuildConnectionString_RejectsInvalidSSLMode covers the parameter
+// injection / silent-downgrade vector from issue #86. Each input would
+// previously have been embedded verbatim into the URL.
+func TestBuildConnectionString_RejectsInvalidSSLMode(t *testing.T) {
+	cases := []string{
+		"off",                  // not a libpq sslmode
+		"true",                 // not a libpq sslmode
+		"prefer&extra=value",   // URL-parameter injection
+		"DISABLE",              // libpq is case-sensitive
+		" require",             // leading whitespace
+		"verify-full;DROP",     // would not actually inject SQL but is plainly wrong
+	}
+	for _, sm := range cases {
+		t.Run(sm, func(t *testing.T) {
+			params := ConnectionParams{
+				Host:     "h",
+				User:     "u",
+				Password: "p",
+				Database: "d",
+				SSLMode:  sm,
+			}
+			_, err := buildConnectionString(params)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidSSLMode)
+		})
+	}
+}
+
+// TestBuildConnectionString_EncodesSpecialCharactersInPassword covers the
+// URL-corruption vector: each of @, /, ?, # in a password would split the
+// URL authority or query under fmt.Sprintf-based construction. Assert that
+// the password round-trips correctly through net/url.Parse, which proves
+// the encoding is structurally valid (issue #86).
+func TestBuildConnectionString_EncodesSpecialCharactersInPassword(t *testing.T) {
+	dangerous := map[string]string{
+		"at-sign":    "p@ss",
+		"slash":      "p/ss",
+		"question":   "p?ss",
+		"hash":       "p#ss",
+		"mixed":      "p@/?#ss",
+		"colon":      "p:ss",
+		"percent":    "p%ss",
+		"whitespace": "p ss",
+	}
+	for name, pw := range dangerous {
+		t.Run(name, func(t *testing.T) {
+			params := ConnectionParams{
+				Host:     "host",
+				Port:     5432,
+				User:     "user",
+				Password: pw,
+				Database: "db",
+			}
+			connStr, err := buildConnectionString(params)
+			require.NoError(t, err)
+
+			// Round-trip: the produced URL must be parseable and the password
+			// must decode back to the original.
+			u, err := url.Parse(connStr)
+			require.NoError(t, err, "produced URL must be parseable")
+			gotPw, hasPw := u.User.Password()
+			require.True(t, hasPw, "password should be present in parsed URL")
+			assert.Equal(t, pw, gotPw, "round-tripped password must match original")
+			assert.Equal(t, "host:5432", u.Host, "host/port must not be split by password content")
+			assert.Equal(t, "/db", u.Path, "path must not be split by password content")
+		})
+	}
 }


### PR DESCRIPTION
buildConnectionString previously embedded user-provided values via
fmt.Sprintf, with two consequences:

  1. sslmode was accepted verbatim, so a crafted value like
     "prefer&extra=value" injected unintended URL parameters and a
     typo like "disabled" or "off" silently downgraded TLS.
  2. Credentials were not URL-encoded, so passwords containing @, /,
     ?, or # corrupted the URL structure (split authority, prematurely
     terminated query, etc.) and surfaced as confusing connection
     errors.

- Add an ErrInvalidSSLMode sentinel and a validSSLModes allowlist of
  the six libpq-recognised values (disable, allow, prefer, require,
  verify-ca, verify-full). Reject anything else before connecting.
- Rebuild the URL through net/url so credentials are percent-encoded
  and host:port goes through net.JoinHostPort. Use url.UserPassword
  unconditionally (even with empty password) to preserve the existing
  "user:@host" shape that callers and tests depend on.
- Keep the default sslmode of "prefer" (PostgreSQL's libpq default)
  to avoid breaking local-dev setups; changing the default is a
  separate behavior change.
- Add three test functions covering the issue's acceptance criteria:
  AcceptsAllValidSSLModes locks the allowlist;
  RejectsInvalidSSLMode covers the injection / downgrade vector
  (incl. "prefer&extra=value", case mismatch, leading whitespace);
  EncodesSpecialCharactersInPassword round-trips passwords with
  @, /, ?, #, :, %, and whitespace through net/url.Parse.

Closes #86