### PR TITLE
fix(main): stop leaking passwords and full query text in debug logs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,12 +20,23 @@ const (
 )
 
 // truncateQuery safely truncates a query string for logging purposes,
-// avoiding logging of potentially sensitive full query text.
+// avoiding logging of potentially sensitive full query text. maxLen is a
+// parameter so unit tests can exercise the cut-off behavior at small
+// lengths; production callers always use maxQueryLogLen via LogSafeQuery.
+//
+//nolint:unparam // see comment above re: test ergonomics
 func truncateQuery(query string, maxLen int) string {
 	if len(query) <= maxLen {
 		return query
 	}
 	return query[:maxLen] + "..."
+}
+
+// LogSafeQuery returns a log-safe (truncated) representation of a query so
+// callers outside this package can avoid emitting full query text — which
+// may carry PII or credentials — to debug/error logs (issue #85).
+func LogSafeQuery(query string) string {
+	return truncateQuery(query, maxQueryLogLen)
 }
 
 // applyLimit wraps a user query in a subquery with an outer LIMIT so that
@@ -310,7 +321,7 @@ func (a *App) ExecuteQuery(ctx context.Context, opts *ExecuteQueryOptions) (*Que
 		return nil, ErrQueryRequired
 	}
 
-	a.logger.Debug("Executing query", "query", opts.Query, "limit", opts.Limit)
+	a.logger.Debug("Executing query", "query", truncateQuery(opts.Query, maxQueryLogLen), "limit", opts.Limit)
 
 	query := opts.Query
 	if opts.Limit > 0 {
@@ -335,7 +346,7 @@ func (a *App) ExecuteQuery(ctx context.Context, opts *ExecuteQueryOptions) (*Que
 			a.logSecurityEvent("multi_statement_query", opts.Query, err)
 			return nil, fmt.Errorf("query rejected: %w", err)
 		}
-		a.logger.Error("Failed to execute query", "error", err, "query", opts.Query)
+		a.logger.Error("Failed to execute query", "error", err, "query", truncateQuery(opts.Query, maxQueryLogLen))
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}
 
@@ -366,7 +377,7 @@ func (a *App) ExplainQuery(ctx context.Context, query string, args ...any) (*Que
 		return nil, ErrQueryRequired
 	}
 
-	a.logger.Debug("Explaining query", "query", query)
+	a.logger.Debug("Explaining query", "query", truncateQuery(query, maxQueryLogLen))
 
 	result, err := a.client.ExplainQuery(ctx, query, args...)
 	if err != nil {
@@ -386,7 +397,7 @@ func (a *App) ExplainQuery(ctx context.Context, query string, args ...any) (*Que
 			a.logSecurityEvent("multi_statement_query", query, err)
 			return nil, fmt.Errorf("query rejected: %w", err)
 		}
-		a.logger.Error("Failed to explain query", "error", err, "query", query)
+		a.logger.Error("Failed to explain query", "error", err, "query", truncateQuery(query, maxQueryLogLen))
 		return nil, fmt.Errorf("failed to explain query: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/lib/pq"
@@ -169,6 +170,21 @@ func getConnectionString(
 	return connectionString, nil
 }
 
+// safeConnectArgs returns a copy of the connect_database args with sensitive
+// fields stripped (password, user, connection_url) so the args map can be
+// safely emitted to debug logs. Only host, port, database, and sslmode are
+// retained — issue #85.
+func safeConnectArgs(args map[string]any) map[string]any {
+	keys := []string{"host", "port", "database", "sslmode"}
+	safe := make(map[string]any, len(keys))
+	for _, k := range keys {
+		if v, ok := args[k]; ok {
+			safe[k] = v
+		}
+	}
+	return safe
+}
+
 // handleConnectDatabaseRequest handles the connect_database tool request.
 func handleConnectDatabaseRequest(
 	ctx context.Context,
@@ -176,7 +192,7 @@ func handleConnectDatabaseRequest(
 	appInstance *app.App,
 	debugLogger *slog.Logger,
 ) (*mcp.CallToolResult, error) {
-	debugLogger.Debug("Received connect_database tool request", "args", args)
+	debugLogger.Debug("Received connect_database tool request", "args", safeConnectArgs(args))
 
 	connectionString, err := getConnectionString(args, debugLogger)
 	if err != nil {
@@ -488,12 +504,15 @@ func setupExecuteQueryTool(s *server.MCPServer, appInstance *app.App, debugLogge
 
 	s.AddTool(executeQueryTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := request.GetArguments()
-		debugLogger.Debug("Received execute_query tool request", "args", args)
+		// Do not dump the raw args map — it carries the full query text which
+		// may include PII or credentials (issue #85). The query is logged in
+		// truncated form below.
+		debugLogger.Debug("Received execute_query tool request")
 
 		// Extract query (required)
 		query, ok := args["query"].(string)
 		if !ok || query == "" {
-			debugLogger.Error("query is missing or not a string", "value", args["query"])
+			debugLogger.Error("query is missing or not a string")
 			return mcp.NewToolResultError("query must be a non-empty string"), nil
 		}
 
@@ -506,12 +525,12 @@ func setupExecuteQueryTool(s *server.MCPServer, appInstance *app.App, debugLogge
 			opts.Limit = int(limitFloat)
 		}
 
-		debugLogger.Debug("Processing execute_query request", "query", query, "limit", opts.Limit)
+		debugLogger.Debug("Processing execute_query request", "query", app.LogSafeQuery(query), "limit", opts.Limit)
 
 		// Execute query
 		result, err := appInstance.ExecuteQuery(ctx, opts)
 		if err != nil {
-			debugLogger.Error("Failed to execute query", "error", err, "query", query)
+			debugLogger.Error("Failed to execute query", "error", err, "query", app.LogSafeQuery(query))
 			return mcp.NewToolResultError(publicError("Failed to execute query", err)), nil
 		}
 
@@ -559,21 +578,24 @@ func setupExplainQueryTool(s *server.MCPServer, appInstance *app.App, debugLogge
 
 	s.AddTool(explainQueryTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		args := request.GetArguments()
-		debugLogger.Debug("Received explain_query tool request", "args", args)
+		// Do not dump the raw args map — it carries the full query text which
+		// may include PII or credentials (issue #85). The query is logged in
+		// truncated form below.
+		debugLogger.Debug("Received explain_query tool request")
 
 		// Extract query (required)
 		query, ok := args["query"].(string)
 		if !ok || query == "" {
-			debugLogger.Error("query is missing or not a string", "value", args["query"])
+			debugLogger.Error("query is missing or not a string")
 			return mcp.NewToolResultError("query must be a non-empty string"), nil
 		}
 
-		debugLogger.Debug("Processing explain_query request", "query", query)
+		debugLogger.Debug("Processing explain_query request", "query", app.LogSafeQuery(query))
 
 		// Explain query
 		result, err := appInstance.ExplainQuery(ctx, query)
 		if err != nil {
-			debugLogger.Error("Failed to explain query", "error", err, "query", query)
+			debugLogger.Error("Failed to explain query", "error", err, "query", app.LogSafeQuery(query))
 			return mcp.NewToolResultError(publicError("Failed to explain query", err)), nil
 		}
 
@@ -631,6 +653,7 @@ ENVIRONMENT VARIABLES (OPTIONAL):
     POSTGRES_MCP_CONN_MAX_LIFETIME  Connection max lifetime in seconds (default: 3600)
     POSTGRES_MCP_CONN_MAX_IDLE_TIME Connection max idle time in seconds (default: 600)
     POSTGRES_MCP_MAX_RESULT_ROWS    Maximum rows returned per query (default: 10000)
+    POSTGRES_MCP_LOG_LEVEL          Log level: debug, info, warn, error (default: info)
 
 DESCRIPTION:
     This MCP server provides the following tools for PostgreSQL integration:
@@ -686,6 +709,19 @@ func handleCommandLineFlags() {
 	}
 }
 
+// resolveLogLevel returns the desired log level from POSTGRES_MCP_LOG_LEVEL,
+// defaulting to "info" when the variable is unset. Comparison is
+// case-insensitive; unknown values fall back to the logger's own default.
+// Hardcoding "debug" here previously surfaced sensitive query text and
+// connection args in production logs (issue #85).
+func resolveLogLevel() string {
+	level := strings.ToLower(strings.TrimSpace(os.Getenv("POSTGRES_MCP_LOG_LEVEL")))
+	if level == "" {
+		return "info"
+	}
+	return level
+}
+
 // initializeApp creates and configures the application instance.
 func initializeApp() (*app.App, *slog.Logger) {
 	// Initialize the app with default client
@@ -694,8 +730,7 @@ func initializeApp() (*app.App, *slog.Logger) {
 		log.Fatalf("Failed to initialize app: %v", err)
 	}
 
-	// Set debug logger
-	debugLogger := logger.NewLogger("debug")
+	debugLogger := logger.NewLogger(resolveLogLevel())
 	appInstance.SetLogger(debugLogger)
 
 	debugLogger.Info("Starting PostgreSQL MCP Server", "version", version)

--- a/main_additional_test.go
+++ b/main_additional_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -632,6 +633,74 @@ func TestBuildConnectionString_EncodesSpecialCharactersInPassword(t *testing.T) 
 			assert.Equal(t, pw, gotPw, "round-tripped password must match original")
 			assert.Equal(t, "host:5432", u.Host, "host/port must not be split by password content")
 			assert.Equal(t, "/db", u.Path, "path must not be split by password content")
+		})
+	}
+}
+
+// TestSafeConnectArgs_RedactsSensitiveFields asserts that the connect_database
+// debug-log sanitizer keeps only the non-sensitive metadata (host, port,
+// database, sslmode) and drops password, user, and connection_url — even
+// when rendered by slog (issue #85).
+func TestSafeConnectArgs_RedactsSensitiveFields(t *testing.T) {
+	args := map[string]any{
+		"host":           "db.example.com",
+		"port":           float64(5432),
+		"user":           "admin",
+		"password":       "s3cret",
+		"database":       "prod",
+		"sslmode":        "require",
+		"connection_url": "postgres://admin:s3cret@db.example.com/prod",
+	}
+
+	safe := safeConnectArgs(args)
+
+	assert.Equal(t, "db.example.com", safe["host"])
+	assert.InDelta(t, 5432.0, safe["port"], 0)
+	assert.Equal(t, "prod", safe["database"])
+	assert.Equal(t, "require", safe["sslmode"])
+
+	_, hasPassword := safe["password"]
+	_, hasUser := safe["user"]
+	_, hasURL := safe["connection_url"]
+	assert.False(t, hasPassword, "password must be stripped from log-safe args")
+	assert.False(t, hasUser, "user must be stripped from log-safe args")
+	assert.False(t, hasURL, "connection_url must be stripped from log-safe args")
+
+	// Defense in depth: the slog rendering of the sanitized map must not
+	// contain the password string anywhere — covers any future field order
+	// change or formatter quirk.
+	var buf bytes.Buffer
+	slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})).
+		Debug("connect", "args", safe)
+	assert.NotContains(t, buf.String(), "s3cret", "log output leaked password")
+	assert.NotContains(t, buf.String(), "admin", "log output leaked username")
+}
+
+// TestResolveLogLevel covers the env-var-driven log level so production
+// deployments stop emitting debug logs by default (issue #85).
+func TestResolveLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"unset defaults to info", "", "info"},
+		{"explicit info", "info", "info"},
+		{"explicit debug", "debug", "debug"},
+		{"uppercase folded", "DEBUG", "debug"},
+		{"mixed case folded", "Warn", "warn"},
+		{"whitespace trimmed", "  error  ", "error"},
+		{"unknown passthrough", "verbose", "verbose"},
+	}
+
+	const key = "POSTGRES_MCP_LOG_LEVEL"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(key, tt.env)
+			if tt.env == "" {
+				require.NoError(t, os.Unsetenv(key))
+			}
+			assert.Equal(t, tt.want, resolveLogLevel())
 		})
 	}
 }


### PR DESCRIPTION
Three log-hygiene fixes for issue #85:

- Sanitize the connect_database debug-log args: only host, port, database,
  and sslmode are retained; password, user, and connection_url are
  stripped via the new safeConnectArgs helper.
- Route every query log field through truncateQuery / app.LogSafeQuery so
  PII and credentials embedded in WHERE clauses cannot exceed the 100-char
  cut-off. Covers execute_query and explain_query in both main.go and
  internal/app/app.go, and drops the raw args-map dump from both tool
  handlers since args carries the full query.
- Replace the hardcoded debug logger in initializeApp with
  POSTGRES_MCP_LOG_LEVEL (default info, case-insensitive, whitespace
  trimmed) via the new resolveLogLevel helper; help text updated.

Closes #85