### PR TITLE
feat(app): add query timeouts and opt-in EXPLAIN ANALYZE

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -565,7 +565,7 @@ func TestIntegration_App_ExplainQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test EXPLAIN query
-	result, err := appInstance.ExplainQuery(ctx, "SELECT * FROM test_mcp_schema.test_users WHERE active = true")
+	result, err := appInstance.ExplainQuery(ctx, "SELECT * FROM test_mcp_schema.test_users WHERE active = true", false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -755,7 +755,7 @@ func TestIntegration_ReadOnlyEnforcement(t *testing.T) {
 	assert.Contains(t, err.Error(), "multi-statement")
 
 	// EXPLAIN ANALYZE on SELECT should still work in read-only mode
-	_, err = client.ExplainQuery(ctx, "SELECT 1")
+	_, err = client.ExplainQuery(ctx, "SELECT 1", true)
 	assert.NoError(t, err)
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -367,8 +367,12 @@ func (a *App) GetCurrentDatabase(ctx context.Context) (string, error) {
 	return dbName, nil
 }
 
-// ExplainQuery returns the execution plan for a query.
-func (a *App) ExplainQuery(ctx context.Context, query string, args ...any) (*QueryResult, error) {
+// ExplainQuery returns the execution plan for a query. When analyze is false
+// (the default for the explain_query MCP tool) the plan is non-executing
+// (EXPLAIN FORMAT JSON); when true it runs EXPLAIN (ANALYZE, BUFFERS, …)
+// which executes the query — bounded by ctx — and may carry the same cost
+// as the underlying SELECT. See issue #89.
+func (a *App) ExplainQuery(ctx context.Context, query string, analyze bool, args ...any) (*QueryResult, error) {
 	if err := a.ensureConnection(ctx); err != nil {
 		return nil, fmt.Errorf("failed to explain query: %w", err)
 	}
@@ -377,9 +381,9 @@ func (a *App) ExplainQuery(ctx context.Context, query string, args ...any) (*Que
 		return nil, ErrQueryRequired
 	}
 
-	a.logger.Debug("Explaining query", "query", truncateQuery(query, maxQueryLogLen))
+	a.logger.Debug("Explaining query", "query", truncateQuery(query, maxQueryLogLen), "analyze", analyze)
 
-	result, err := a.client.ExplainQuery(ctx, query, args...)
+	result, err := a.client.ExplainQuery(ctx, query, analyze, args...)
 	if err != nil {
 		if errors.Is(err, ErrResultTooLarge) {
 			a.logSecurityEvent("result_too_large", query, err)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -101,8 +101,8 @@ func (m *MockPostgreSQLClient) ExecuteQuery(ctx context.Context, query string, q
 	return mockArgs.Get(0).(*QueryResult), mockArgs.Error(1)
 }
 
-func (m *MockPostgreSQLClient) ExplainQuery(ctx context.Context, query string, queryArgs ...any) (*QueryResult, error) {
-	mockArgs := m.Called(ctx, query, queryArgs)
+func (m *MockPostgreSQLClient) ExplainQuery(ctx context.Context, query string, analyze bool, queryArgs ...any) (*QueryResult, error) {
+	mockArgs := m.Called(ctx, query, analyze, queryArgs)
 	if mockArgs.Get(0) == nil {
 		return nil, mockArgs.Error(1)
 	}
@@ -517,9 +517,9 @@ func TestApp_ExplainQuery(t *testing.T) {
 	}
 
 	mockClient.On("Ping", mock.Anything).Return(nil)
-	mockClient.On("ExplainQuery", mock.Anything, "SELECT * FROM users", []interface{}(nil)).Return(expectedResult, nil)
+	mockClient.On("ExplainQuery", mock.Anything, "SELECT * FROM users", false, []interface{}(nil)).Return(expectedResult, nil)
 
-	result, err := app.ExplainQuery(context.Background(), "SELECT * FROM users")
+	result, err := app.ExplainQuery(context.Background(), "SELECT * FROM users", false)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResult, result)
 	mockClient.AssertExpectations(t)
@@ -528,7 +528,7 @@ func TestApp_ExplainQuery(t *testing.T) {
 func TestApp_ExplainQueryEmptyQuery(t *testing.T) {
 	app, _ := NewDefault()
 
-	result, err := app.ExplainQuery(context.Background(), "")
+	result, err := app.ExplainQuery(context.Background(), "", false)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "database connection failed")
@@ -695,9 +695,9 @@ func TestApp_ExplainQuery_SecurityAudit_InvalidQuery(t *testing.T) {
 	query := "DELETE FROM users"
 
 	mockClient.On("Ping", mock.Anything).Return(nil)
-	mockClient.On("ExplainQuery", mock.Anything, query, []interface{}(nil)).Return((*QueryResult)(nil), ErrInvalidQuery)
+	mockClient.On("ExplainQuery", mock.Anything, query, false, []interface{}(nil)).Return((*QueryResult)(nil), ErrInvalidQuery)
 
-	result, err := app.ExplainQuery(context.Background(), query)
+	result, err := app.ExplainQuery(context.Background(), query, false)
 	assert.Nil(t, result)
 	assert.ErrorIs(t, err, ErrInvalidQuery)
 	mockClient.AssertExpectations(t)

--- a/internal/app/client.go
+++ b/internal/app/client.go
@@ -44,12 +44,40 @@ const (
 	// countFallbackTimeout caps each COUNT(*) fallback call so a single billion-row
 	// table cannot tie up a pool connection for minutes (issue #90).
 	countFallbackTimeout = 5 * time.Second
+
+	// defaultQueryTimeout bounds every tool handler's context and is also
+	// pushed into the connection options as statement_timeout so PostgreSQL
+	// cancels a runaway query even if the client context is unbounded
+	// (issue #89). Overridable via POSTGRES_MCP_QUERY_TIMEOUT.
+	defaultQueryTimeout = 30 * time.Second
 )
 
-// injectReadOnlyOption appends default_transaction_read_only=on to the connection string
-// so that every connection in the pool is read-only at the PostgreSQL level.
-// Handles both URL-style (postgres://...) and keyword-value style connection strings.
-func injectReadOnlyOption(connStr string) string {
+// QueryTimeout resolves the query timeout from POSTGRES_MCP_QUERY_TIMEOUT,
+// defaulting to defaultQueryTimeout when unset, blank, or unparseable.
+// The value accepts Go duration syntax ("45s", "2m", "500ms"); bare integers
+// are treated as seconds for ergonomic shell use. Non-positive values fall
+// back to the default so a misconfiguration cannot silently disable the
+// timeout (issue #89).
+func QueryTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("POSTGRES_MCP_QUERY_TIMEOUT"))
+	if raw == "" {
+		return defaultQueryTimeout
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		return d
+	}
+	if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return defaultQueryTimeout
+}
+
+// injectOption appends a single "-c key=value"-style server option to the
+// PostgreSQL connection string's options= payload, handling both URL-style
+// (postgres://...) and keyword-value style DSNs. Multiple options can be
+// added by calling this function repeatedly; each call appends to whatever
+// options payload already exists.
+func injectOption(connStr, opt string) string {
 	connStr = strings.TrimSpace(connStr)
 	if connStr == "" {
 		return connStr
@@ -64,9 +92,9 @@ func injectReadOnlyOption(connStr string) string {
 		q := u.Query()
 		existing := q.Get("options")
 		if existing != "" {
-			q.Set("options", existing+" "+readOnlyOption)
+			q.Set("options", existing+" "+opt)
 		} else {
-			q.Set("options", readOnlyOption)
+			q.Set("options", opt)
 		}
 		u.RawQuery = q.Encode()
 		return u.String()
@@ -75,7 +103,7 @@ func injectReadOnlyOption(connStr string) string {
 	// Keyword-value style connection string.
 	optionsIdx := strings.Index(connStr, "options=")
 	if optionsIdx == -1 {
-		return connStr + " options='" + readOnlyOption + "'"
+		return connStr + " options='" + opt + "'"
 	}
 	valStart := optionsIdx + len("options=")
 
@@ -87,19 +115,36 @@ func injectReadOnlyOption(connStr string) string {
 			return connStr
 		}
 		closeIdx := valStart + 1 + closeRel
-		return connStr[:closeIdx] + " " + readOnlyOption + connStr[closeIdx:]
+		return connStr[:closeIdx] + " " + opt + connStr[closeIdx:]
 	}
 
 	// Unquoted form (issue #84): value runs to next whitespace or EOS.
 	// Rewrite as the quoted form so a multi-token options payload stays a
 	// single value; previously this branch silently returned the DSN
-	// unchanged, skipping the read-only enforcement.
+	// unchanged, skipping the option-injection guarantee.
 	valEnd := len(connStr)
 	if rel := strings.IndexAny(connStr[valStart:], " \t\n"); rel != -1 {
 		valEnd = valStart + rel
 	}
 	existing := connStr[valStart:valEnd]
-	return connStr[:optionsIdx] + "options='" + existing + " " + readOnlyOption + "'" + connStr[valEnd:]
+	return connStr[:optionsIdx] + "options='" + existing + " " + opt + "'" + connStr[valEnd:]
+}
+
+// injectReadOnlyOption appends default_transaction_read_only=on to the connection
+// string so every pool connection is read-only at the PostgreSQL session level.
+func injectReadOnlyOption(connStr string) string {
+	return injectOption(connStr, readOnlyOption)
+}
+
+// injectStatementTimeout appends a server-side statement_timeout (milliseconds)
+// to the connection options so a runaway query is killed by PostgreSQL itself
+// even when the caller's context is unbounded (issue #89). A non-positive
+// duration is a no-op.
+func injectStatementTimeout(connStr string, d time.Duration) string {
+	if d <= 0 {
+		return connStr
+	}
+	return injectOption(connStr, fmt.Sprintf("-c statement_timeout=%d", d.Milliseconds()))
 }
 
 // PostgreSQLClientImpl implements the PostgreSQLClient interface.
@@ -153,8 +198,8 @@ func maxResultRows() int {
 //   - POSTGRES_MCP_CONN_MAX_LIFETIME (seconds, default: 3600)
 //   - POSTGRES_MCP_CONN_MAX_IDLE_TIME (seconds, default: 600)
 func (c *PostgreSQLClientImpl) Connect(ctx context.Context, connectionString string) error {
-	readOnlyConnStr := injectReadOnlyOption(connectionString)
-	db, err := sql.Open("postgres", readOnlyConnStr)
+	hardenedConnStr := injectStatementTimeout(injectReadOnlyOption(connectionString), QueryTimeout())
+	db, err := sql.Open("postgres", hardenedConnStr)
 	if err != nil {
 		return fmt.Errorf("failed to open database connection: %w", err)
 	}
@@ -826,8 +871,13 @@ func (c *PostgreSQLClientImpl) ExecuteQuery(ctx context.Context, query string, a
 	}, nil
 }
 
-// ExplainQuery returns the execution plan for a query.
-func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, args ...any) (*QueryResult, error) {
+// ExplainQuery returns the execution plan for a query. When analyze is false
+// the plan is non-executing — EXPLAIN (FORMAT JSON) — which is the safe
+// default for an LLM-driven tool surface that may submit heavy queries
+// (issue #89). When analyze is true the query is executed via
+// EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON); the caller's context bounds the
+// run, complementing the server-side statement_timeout.
+func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, analyze bool, args ...any) (*QueryResult, error) {
 	if err := validateQuery(query); err != nil {
 		return nil, err
 	}
@@ -837,8 +887,11 @@ func (c *PostgreSQLClientImpl) ExplainQuery(ctx context.Context, query string, a
 		return nil, ErrNoDatabaseConnection
 	}
 
-	// Construct the EXPLAIN query
-	explainQuery := "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) " + query //nolint:gosec // query is validated by validateQuery above (SELECT/WITH only)
+	prefix := "EXPLAIN (FORMAT JSON) "
+	if analyze {
+		prefix = "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) "
+	}
+	explainQuery := prefix + query //nolint:gosec // query is validated by validateQuery above (SELECT/WITH only)
 
 	rows, err := db.QueryContext(ctx, explainQuery, args...)
 	if err != nil {

--- a/internal/app/client_mocked_test.go
+++ b/internal/app/client_mocked_test.go
@@ -118,7 +118,7 @@ func TestPostgreSQLClient_ErrorScenarios(t *testing.T) {
 	})
 
 	t.Run("ExplainQuery", func(t *testing.T) {
-		_, err := client.ExplainQuery(context.Background(), "SELECT 1")
+		_, err := client.ExplainQuery(context.Background(), "SELECT 1", false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no database connection")
 	})

--- a/internal/app/client_test.go
+++ b/internal/app/client_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPostgreSQLClient(t *testing.T) {
@@ -275,7 +276,7 @@ func TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99(t *testing
 	})
 
 	t.Run("ExplainQuery rejects DROP before connection check", func(t *testing.T) {
-		_, err := client.ExplainQuery(context.Background(), "DROP TABLE users")
+		_, err := client.ExplainQuery(context.Background(), "DROP TABLE users", false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "only SELECT and WITH queries are allowed")
 	})
@@ -287,7 +288,7 @@ func TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99(t *testing
 	})
 
 	t.Run("ExplainQuery still reports missing connection for valid queries", func(t *testing.T) {
-		_, err := client.ExplainQuery(context.Background(), "SELECT 1")
+		_, err := client.ExplainQuery(context.Background(), "SELECT 1", false)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no database connection")
 	})
@@ -295,7 +296,7 @@ func TestPostgreSQLClient_ValidationRunsBeforeConnectionCheck_Issue99(t *testing
 
 func TestPostgreSQLClient_ExplainQueryWithoutConnection(t *testing.T) {
 	client := NewPostgreSQLClient()
-	result, err := client.ExplainQuery(context.Background(), "SELECT 1")
+	result, err := client.ExplainQuery(context.Background(), "SELECT 1", false)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "no database connection")
@@ -321,7 +322,7 @@ func TestPostgreSQLClient_ExplainQueryValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// This will fail due to no real connection, but we're testing the query validation
-			result, err := client.ExplainQuery(context.Background(), tt.query)
+			result, err := client.ExplainQuery(context.Background(), tt.query, false)
 			assert.Error(t, err)
 			assert.Nil(t, result)
 			// Should fail with connection error since no real connection
@@ -710,6 +711,79 @@ func TestInjectReadOnlyOption_UnterminatedQuotedOptions_LeftAlone(t *testing.T) 
 	in := "host=localhost options='-c foo=bar"
 	out := injectReadOnlyOption(in)
 	assert.Equal(t, in, out)
+}
+
+// TestInjectStatementTimeout covers the issue #89 statement_timeout injection
+// across both DSN shapes plus the zero-duration no-op contract.
+func TestInjectStatementTimeout(t *testing.T) {
+	t.Run("URL-style appends statement_timeout in milliseconds", func(t *testing.T) {
+		out := injectStatementTimeout("postgres://u:p@h/db", 30*time.Second)
+		assert.Contains(t, out, "statement_timeout%3D30000",
+			"30s must serialize as 30000ms inside the URL options payload")
+	})
+
+	t.Run("keyword-value style appends statement_timeout", func(t *testing.T) {
+		out := injectStatementTimeout("host=localhost dbname=mydb", 1500*time.Millisecond)
+		assert.Contains(t, out, "-c statement_timeout=1500",
+			"sub-second durations must round to integer milliseconds")
+	})
+
+	t.Run("zero duration is a no-op", func(t *testing.T) {
+		in := "postgres://u:p@h/db"
+		assert.Equal(t, in, injectStatementTimeout(in, 0))
+	})
+
+	t.Run("negative duration is a no-op", func(t *testing.T) {
+		in := "host=localhost"
+		assert.Equal(t, in, injectStatementTimeout(in, -1*time.Second))
+	})
+
+	t.Run("composes with read-only injection in a single options payload", func(t *testing.T) {
+		// Issue #89: Connect chains both injections. Assert that the resulting
+		// DSN carries BOTH options inside a single options= value rather than
+		// producing a malformed second options= key (which lib/pq would
+		// silently drop the earlier one of).
+		in := "host=localhost dbname=mydb"
+		stacked := injectStatementTimeout(injectReadOnlyOption(in), 30*time.Second)
+		assert.Contains(t, stacked, "default_transaction_read_only=on")
+		assert.Contains(t, stacked, "statement_timeout=30000")
+		assert.Equal(t, 1, strings.Count(stacked, "options="),
+			"both options must share one options= payload, not produce two keys")
+	})
+}
+
+// TestQueryTimeout covers the issue #89 env-var-driven timeout resolution,
+// including the duration-string / bare-seconds dual format and the
+// fail-safe behavior on invalid or non-positive input.
+func TestQueryTimeout(t *testing.T) {
+	const key = "POSTGRES_MCP_QUERY_TIMEOUT"
+
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset returns default", "", defaultQueryTimeout},
+		{"duration string", "45s", 45 * time.Second},
+		{"duration with units", "2m", 2 * time.Minute},
+		{"sub-second duration", "500ms", 500 * time.Millisecond},
+		{"bare integer treated as seconds", "10", 10 * time.Second},
+		{"zero falls back to default", "0", defaultQueryTimeout},
+		{"negative falls back to default", "-5s", defaultQueryTimeout},
+		{"garbage falls back to default", "soon", defaultQueryTimeout},
+		{"whitespace tolerated", "  20s  ", 20 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env == "" {
+				require.NoError(t, os.Unsetenv(key))
+			} else {
+				t.Setenv(key, tt.env)
+			}
+			assert.Equal(t, tt.want, QueryTimeout())
+		})
+	}
 }
 
 func TestEnvIntOrDefault(t *testing.T) {

--- a/internal/app/interfaces.go
+++ b/internal/app/interfaces.go
@@ -122,8 +122,11 @@ type QueryExecutor interface {
 	// ExecuteQuery runs a validated SELECT/WITH query and returns the result set.
 	// Queries are validated for safety (no mutations, no multi-statement, size limits).
 	ExecuteQuery(ctx context.Context, query string, args ...any) (*QueryResult, error)
-	// ExplainQuery returns the EXPLAIN ANALYZE execution plan for a query as JSON.
-	ExplainQuery(ctx context.Context, query string, args ...any) (*QueryResult, error)
+	// ExplainQuery returns the execution plan for a query as JSON. When analyze
+	// is false the plan is non-executing (EXPLAIN FORMAT JSON); when true it
+	// runs EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON), which actually executes
+	// the query and is bounded by the caller's context (issue #89).
+	ExplainQuery(ctx context.Context, query string, analyze bool, args ...any) (*QueryResult, error)
 }
 
 // PostgreSQLClient combines all database operations into a single read-only interface.

--- a/main.go
+++ b/main.go
@@ -170,6 +170,15 @@ func getConnectionString(
 	return connectionString, nil
 }
 
+// withQueryTimeout wraps the caller's context with the operator-configured
+// query timeout (POSTGRES_MCP_QUERY_TIMEOUT, default 30s) so any tool handler
+// — including a pathological SELECT through execute_query or an
+// EXPLAIN ANALYZE — cancels cleanly instead of holding a pool connection
+// indefinitely (issue #89). Callers must defer the returned cancel.
+func withQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, app.QueryTimeout())
+}
+
 // safeConnectArgs returns a copy of the connect_database args with sensitive
 // fields stripped (password, user, connection_url) so the args map can be
 // safely emitted to debug logs. Only host, port, database, and sslmode are
@@ -199,8 +208,11 @@ func handleConnectDatabaseRequest(
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	qctx, cancel := withQueryTimeout(ctx)
+	defer cancel()
+
 	// Attempt to connect
-	if err := appInstance.Connect(ctx, connectionString); err != nil {
+	if err := appInstance.Connect(qctx, connectionString); err != nil {
 		// Issue #88: pre-auth errors leak host/port (*net.OpError), username,
 		// and auth method (*pq.Error.Message). Return a fixed generic
 		// message regardless of error class; the full chain is logged above.
@@ -210,7 +222,7 @@ func handleConnectDatabaseRequest(
 	}
 
 	// Get current database name to confirm connection
-	dbName, err := appInstance.GetCurrentDatabase(ctx)
+	dbName, err := appInstance.GetCurrentDatabase(qctx)
 	if err != nil {
 		debugLogger.Warn("Connected but failed to get database name", "error", err)
 		dbName = "unknown"
@@ -266,6 +278,10 @@ func setupConnectDatabaseTool(s *server.MCPServer, appInstance *app.App, debugLo
 }
 
 // setupListDatabasesTool creates and registers the list_databases tool.
+//
+//nolint:dupl // structurally parallel to setupListSchemasTool by design; both
+// follow the same no-arg list → JSON → return shape, and merging them into a
+// generic registrar would obscure rather than clarify the tool wiring.
 func setupListDatabasesTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
 	listDBTool := mcp.NewTool("list_databases",
 		mcp.WithDescription("List all databases on the PostgreSQL server"),
@@ -273,9 +289,11 @@ func setupListDatabasesTool(s *server.MCPServer, appInstance *app.App, debugLogg
 
 	s.AddTool(listDBTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		debugLogger.Debug("Received list_databases tool request")
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
 
 		// List databases
-		databases, err := appInstance.ListDatabases(ctx)
+		databases, err := appInstance.ListDatabases(qctx)
 		if err != nil {
 			debugLogger.Error("Failed to list databases", "error", err)
 			return mcp.NewToolResultError(publicError("Failed to list databases", err)), nil
@@ -294,6 +312,8 @@ func setupListDatabasesTool(s *server.MCPServer, appInstance *app.App, debugLogg
 }
 
 // setupListSchemasTool creates and registers the list_schemas tool.
+//
+//nolint:dupl // structurally parallel to setupListDatabasesTool — see note there.
 func setupListSchemasTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
 	listSchemasTool := mcp.NewTool("list_schemas",
 		mcp.WithDescription("List all schemas in the current database"),
@@ -301,9 +321,11 @@ func setupListSchemasTool(s *server.MCPServer, appInstance *app.App, debugLogger
 
 	s.AddTool(listSchemasTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		debugLogger.Debug("Received list_schemas tool request")
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
 
 		// List schemas
-		schemas, err := appInstance.ListSchemas(ctx)
+		schemas, err := appInstance.ListSchemas(qctx)
 		if err != nil {
 			debugLogger.Error("Failed to list schemas", "error", err)
 			return mcp.NewToolResultError(publicError("Failed to list schemas", err)), nil
@@ -350,8 +372,11 @@ func setupListTablesTool(s *server.MCPServer, appInstance *app.App, debugLogger 
 
 		debugLogger.Debug("Processing list_tables request", schemaKey, opts.Schema, "include_size", opts.IncludeSize)
 
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
+
 		// List tables
-		tables, err := appInstance.ListTables(ctx, opts)
+		tables, err := appInstance.ListTables(qctx, opts)
 		if err != nil {
 			debugLogger.Error("Failed to list tables", "error", err)
 			return mcp.NewToolResultError(publicError("Failed to list tables", err)), nil
@@ -452,7 +477,10 @@ func setupTableTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		result, err := config.Operation(ctx, appInstance, schema, table)
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
+
+		result, err := config.Operation(qctx, appInstance, schema, table)
 		if err != nil {
 			debugLogger.Error("Failed to "+config.ErrorMsg, "error", err, schemaKey, schema, tableKey, table)
 			return mcp.NewToolResultError(publicError("Failed to "+config.ErrorMsg, err)), nil
@@ -527,8 +555,11 @@ func setupExecuteQueryTool(s *server.MCPServer, appInstance *app.App, debugLogge
 
 		debugLogger.Debug("Processing execute_query request", "query", app.LogSafeQuery(query), "limit", opts.Limit)
 
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
+
 		// Execute query
-		result, err := appInstance.ExecuteQuery(ctx, opts)
+		result, err := appInstance.ExecuteQuery(qctx, opts)
 		if err != nil {
 			debugLogger.Error("Failed to execute query", "error", err, "query", app.LogSafeQuery(query))
 			return mcp.NewToolResultError(publicError("Failed to execute query", err)), nil
@@ -569,10 +600,14 @@ func setupListIndexesTool(s *server.MCPServer, appInstance *app.App, debugLogger
 // setupExplainQueryTool creates and registers the explain_query tool.
 func setupExplainQueryTool(s *server.MCPServer, appInstance *app.App, debugLogger *slog.Logger) {
 	explainQueryTool := mcp.NewTool("explain_query",
-		mcp.WithDescription("Get the execution plan for a SQL query"),
+		mcp.WithDescription("Get the execution plan for a SQL query. Defaults to a non-executing plan; "+
+			"pass analyze=true to run EXPLAIN ANALYZE (executes the query — same cost and timeout as execute_query)."),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("SQL query to explain (SELECT or WITH statements only)"),
+		),
+		mcp.WithBoolean("analyze",
+			mcp.Description("If true, run EXPLAIN (ANALYZE, BUFFERS) which executes the query. Default: false (plan only)."),
 		),
 	)
 
@@ -590,10 +625,15 @@ func setupExplainQueryTool(s *server.MCPServer, appInstance *app.App, debugLogge
 			return mcp.NewToolResultError("query must be a non-empty string"), nil
 		}
 
-		debugLogger.Debug("Processing explain_query request", "query", app.LogSafeQuery(query))
+		analyze, _ := args["analyze"].(bool)
+
+		debugLogger.Debug("Processing explain_query request", "query", app.LogSafeQuery(query), "analyze", analyze)
+
+		qctx, cancel := withQueryTimeout(ctx)
+		defer cancel()
 
 		// Explain query
-		result, err := appInstance.ExplainQuery(ctx, query)
+		result, err := appInstance.ExplainQuery(qctx, query, analyze)
 		if err != nil {
 			debugLogger.Error("Failed to explain query", "error", err, "query", app.LogSafeQuery(query))
 			return mcp.NewToolResultError(publicError("Failed to explain query", err)), nil
@@ -654,6 +694,9 @@ ENVIRONMENT VARIABLES (OPTIONAL):
     POSTGRES_MCP_CONN_MAX_IDLE_TIME Connection max idle time in seconds (default: 600)
     POSTGRES_MCP_MAX_RESULT_ROWS    Maximum rows returned per query (default: 10000)
     POSTGRES_MCP_LOG_LEVEL          Log level: debug, info, warn, error (default: info)
+    POSTGRES_MCP_QUERY_TIMEOUT      Per-tool-call timeout. Duration ("30s", "2m") or
+                                    bare integer seconds (default: 30s). Also pushed
+                                    into the connection's statement_timeout.
 
 DESCRIPTION:
     This MCP server provides the following tools for PostgreSQL integration:

--- a/main_additional_test.go
+++ b/main_additional_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -462,7 +463,7 @@ func (s *stubFailingClient) ListIndexes(_ context.Context, _, _ string) ([]*app.
 func (s *stubFailingClient) ExecuteQuery(_ context.Context, _ string, _ ...any) (*app.QueryResult, error) {
 	return nil, errors.New("stub")
 }
-func (s *stubFailingClient) ExplainQuery(_ context.Context, _ string, _ ...any) (*app.QueryResult, error) {
+func (s *stubFailingClient) ExplainQuery(_ context.Context, _ string, _ bool, _ ...any) (*app.QueryResult, error) {
 	return nil, errors.New("stub")
 }
 
@@ -674,6 +675,27 @@ func TestSafeConnectArgs_RedactsSensitiveFields(t *testing.T) {
 		Debug("connect", "args", safe)
 	assert.NotContains(t, buf.String(), "s3cret", "log output leaked password")
 	assert.NotContains(t, buf.String(), "admin", "log output leaked username")
+}
+
+// TestWithQueryTimeout asserts that the per-handler timeout wrapper bounds
+// the returned context using the configured POSTGRES_MCP_QUERY_TIMEOUT
+// (issue #89). It must always return a non-nil cancel — otherwise the
+// caller's defer is silently a no-op.
+func TestWithQueryTimeout(t *testing.T) {
+	t.Setenv("POSTGRES_MCP_QUERY_TIMEOUT", "75ms")
+
+	qctx, cancel := withQueryTimeout(context.Background())
+	require.NotNil(t, cancel)
+	t.Cleanup(cancel)
+
+	deadline, ok := qctx.Deadline()
+	require.True(t, ok, "wrapped context must have a deadline")
+
+	remaining := time.Until(deadline)
+	assert.LessOrEqual(t, remaining, 75*time.Millisecond,
+		"deadline must be at most the configured timeout")
+	assert.Greater(t, remaining, time.Duration(0),
+		"deadline must be in the future, not already expired")
 }
 
 // TestResolveLogLevel covers the env-var-driven log level so production


### PR DESCRIPTION
Addresses the three DoS / pool-starvation vectors from issue #89:

- New POSTGRES_MCP_QUERY_TIMEOUT (default 30s, duration syntax or bare
  seconds) drives both the handler-side context deadline and the
  server-side statement_timeout.
- Every tool handler in main.go now wraps the caller's context with
  withQueryTimeout(ctx) so a pathological SELECT, an EXPLAIN ANALYZE, or
  a hung connect_database cancels cleanly instead of holding a pool
  connection. The wrap also covers connect_database, list_databases,
  list_schemas, list_tables, describe_table, list_indexes, execute_query,
  explain_query, and get_table_stats.
- injectStatementTimeout pushes statement_timeout=<ms> into the
  connection's options payload alongside the existing read-only flag,
  using a refactored generic injectOption helper so both options share a
  single options= value across URL-style and keyword-value DSNs.
- explain_query now defaults to a non-executing plan
  (EXPLAIN FORMAT JSON); pass analyze=true to opt into
  EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON), with the cost called out in
  the tool description.

Help text and mocks updated accordingly. New unit tests cover
QueryTimeout env-var parsing (9 cases including duration syntax,
whitespace, fail-safe defaults), injectStatementTimeout (URL-style,
keyword-value, no-op zero/negative, composition with read-only), and
withQueryTimeout deadline enforcement.

Closes #89